### PR TITLE
Content Security Policy Fix for Google Analytics

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -35,6 +35,7 @@ app.use(helmet.contentSecurityPolicy({
       'www.google-analytics.com',
       "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
       "'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='"],
+    connectSrc: ["'self'", 'www.google-analytics.com'],
     styleSrc: ["'self'"],
     fontSrc: ["'self'", 'data:'],
     imgSrc: ["'self'", 'www.google-analytics.com']


### PR DESCRIPTION
Add 'www.google-analytics.com' to connect-src to fix Google Analytics browser console errors relating to Content Security Policy.