### PR TITLE
Hwpv 125 update notification banner with new date for voucher withdrawal

### DIFF
--- a/app/views/apply/eligibility/claim/bank-payment-details.html
+++ b/app/views/apply/eligibility/claim/bank-payment-details.html
@@ -7,7 +7,7 @@
   <h3 class="govuk-notification-banner__heading">
     Payment by cash voucher to end
   </h3>
-  <p class="govuk-body">At the end of 2023, claims will only be paid to your bank account.</p>
+  <p class="govuk-body">The payment by cash voucher option will no longer be available from 8 January 2024.</p>
   <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="mailto:familyservices.management@justice.gov.uk">familyservices.management@justice.gov.uk</a> for more information.</p>
 {% endset %}
 

--- a/app/views/apply/eligibility/claim/payout-confirmation.html
+++ b/app/views/apply/eligibility/claim/payout-confirmation.html
@@ -6,7 +6,7 @@
   <h3 class="govuk-notification-banner__heading">
     Payment by cash voucher to end
   </h3>
-  <p class="govuk-body">At the end of 2023, claims will only be paid to your bank account.</p>
+  <p class="govuk-body">The payment by cash voucher option will no longer be available from 8 January 2024.</p>
   <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="mailto:familyservices.management@justice.gov.uk">familyservices.management@justice.gov.uk</a> for more information.</p>
 {% endset %}
 


### PR DESCRIPTION
We have been informed that the date of removing the voucher payment has been finalised. Family Services are continuing with informing customers of the pending removal and have asked us to update the notification to say:

> Payment by cash voucher to end
>The payment by cash voucher option will no longer be available from 8 January 2024.
> Contact [familyservices.management@justice.gov.uk](mailto:familyservices.management@justice.gov.uk) for more information.

This needs to be updated on the following pages:

* Bank account details
* voucher confirmation