### PR TITLE
HWPV-124 Add common vars to preprod deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,9 @@ workflows:
           <<: *feature_branch
           name: deploy_preprod_preview
           env: "preprod"
-          context: help-with-prison-visits-external-preprod
+          context:
+            - hmpps-common-vars
+            - help-with-prison-visits-external-preprod
           requires:
             - request_preprod_approval_branch
       - hmpps/deploy_env:
@@ -140,7 +142,9 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
-          context: help-with-prison-visits-external-preprod
+          context:
+            - hmpps-common-vars
+            - help-with-prison-visits-external-preprod
           requires:
             - request_preprod_approval
       - request_prod_approval:


### PR DESCRIPTION
New IP allow lists weren't working for preprod because it was lacking the `hmpps-common-vars` context so couldn't get the IP groups.