### PR TITLE
Fixed poorly rendered text for when a contact has been updated

### DIFF
--- a/app/constants/claim-event-enum.js
+++ b/app/constants/claim-event-enum.js
@@ -2,5 +2,6 @@ module.exports = {
   'CLAIM-APPROVED': 'Claim approved',
   'CLAIM-REJECTED': 'Claim rejected',
   'CLAIM-REQUEST-INFORMATION': 'Requested Information',
-  'CLOSE-ADVANCE-CLAIM': 'Advance claim closed'
+  'CLOSE-ADVANCE-CLAIM': 'Advance claim closed',
+  'UPDATED-CONTACT-DETAILS': 'Contact details updated'
 }

--- a/test/unit/views/helpers/test-claim-event-helper.js
+++ b/test/unit/views/helpers/test-claim-event-helper.js
@@ -4,6 +4,8 @@ describe('views/helpers/claim-event-helper', function () {
   const APPROVED = 'CLAIM-APPROVED'
   const REQUEST_INFORMATION = 'CLAIM-REQUEST-INFORMATION'
   const REJECTED = 'CLAIM-REJECTED'
+  const REQUESTED = 'CLAIM-REQUEST-INFORMATION'
+  const CONTACT = 'UPDATED-CONTACT-DETAILS'
   const NON_MATCHING = ''
 
   it(`should return the expected value when passed ${APPROVED}`, function () {
@@ -16,6 +18,14 @@ describe('views/helpers/claim-event-helper', function () {
 
   it(`should return the expected value when passed ${REJECTED}`, function () {
     expect(claimEventHelper(REJECTED)).toBe('Claim rejected')
+  })
+
+  it(`should return the expected value when passed ${REQUESTED}`, function () {
+    expect(claimEventHelper(REQUESTED)).toBe('Requested Information')
+  })
+
+  it(`should return the expected value when passed ${CONTACT}`, function () {
+    expect(claimEventHelper(CONTACT)).toBe('Contact details updated')
   })
 
   it('should return the original input if passed a non-matching value', function () {


### PR DESCRIPTION
In the claims  history, we showed poorly rendered text when a contact had been updated for a claim.

This PR improves the wording by added an additional enum and updateing the relevant unit tests.