### PR TITLE
removed explanatory text and two Tax Credit options

### DIFF
--- a/app/views/apply/new-eligibility/benefits.html
+++ b/app/views/apply/new-eligibility/benefits.html
@@ -1,7 +1,6 @@
 {% extends "includes/layout.html" %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% if relationship === 'eligible-child' %}
   {% set titleText = "Is the eligible child covered by any of the following" %}
@@ -22,10 +21,6 @@
     <h1 class="govuk-heading-l">
       {{ titleText }}?
     </h1>
-
-    {{ govukInsetText({
-      text: "Tax credits end on 5 April. Any claims based on tax credits for visits after 5 April will be rejected."
-    }) }}
 
     <form action="{{ URL }}" method="post">
 
@@ -78,16 +73,6 @@
             }
           },
           {
-            value: "b5",
-            text: "Working Tax credits (with disability or child tax) or Child Tax Credit",
-            hint: {
-              text: "While earning less than £17,474 a year"
-            },
-            attributes: {
-              "data-cy": "tax-credits"
-            }
-          },
-          {
             value: "b6",
             text: "Pension Credit",
             attributes: {
@@ -106,13 +91,6 @@
             text: "Health Certificate (HC3)",
             attributes: {
               "data-cy": "hc3"
-            }
-          },
-          {
-            value: "b9",
-            text: "NHS Tax Credit Exemption Certificate",
-            attributes: {
-              "data-cy": "tax-credit"
             }
           },
           ({


### PR DESCRIPTION
**Background**

Tax credits are ending on 5 April 2025 - Universal Credit is replacing tax credits. The Department for Work and Pensions (DWP) or the Department for Communities (for Northern Ireland customers) will write to all eligible customers during 2024 and inform them of the need to move to Universal Credit, to continue to receive financial support.  

We need to remove reference to Tax credits from the service from 3 May 2025 (28 days after the 5 April).

Evidence

[Tax credits are ending on 5 April 2025 - Community Forum - GOV.UK](https://community.hmrc.gov.uk/customerforums/taxcredits/d5069abf-5add-ee11-904d-6045bd127724#:~:text=This%20letter%20is%20called%20a,ends%20their%20tax%20credits%20sooner.)
