### PR TITLE
Hwpv 238 update public service to gov.uk rebranded styles

### DIFF
--- a/app/views/includes/layout.html
+++ b/app/views/includes/layout.html
@@ -14,7 +14,7 @@
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk",
     containerClasses: "govuk-width-container",
-    classes: "govuk-header--full-width-border"
+    rebrand: true
   }) }}
   {{ govukServiceNavigation({
     serviceName: serviceName,
@@ -48,6 +48,7 @@
 
 {% block footer %}
   {{ govukFooter({
+    rebrand: true,
     meta: {
       items: [
         {

--- a/app/views/includes/layout.html
+++ b/app/views/includes/layout.html
@@ -3,6 +3,7 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% set govukRebrand = true %}
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet">


### PR DESCRIPTION
Adds new branding to reflect the new [GOV.UK rebrand](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0)

DO NOT MAKE LIVE UNTIL:  25 June 2025